### PR TITLE
Remove unnecessary Visual Studio specific section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,6 @@ source:
 build:
     number: 0
     script: python setup.py install
-    features:
-        - vc9   # [win and py27]
-        - vc10  # [win and py34]
-        - vc14  # [win and py35]
 
 requirements:
   build:


### PR DESCRIPTION
since nibabel is a pure python package.

I asked for nilearn whether this section was needed and I was told it wasn't: https://github.com/conda-forge/staged-recipes/pull/590#discussion_r62998438.