### PR TITLE
Add effigies to maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,4 @@ extra:
   recipe-maintainers:
     - arokem
     - grlee77
+    - effigies


### PR DESCRIPTION
Seems safe to do `[skip ci]`? Can amend, if you want to make run it anyway.